### PR TITLE
Format dates and times

### DIFF
--- a/create_prj_db.R
+++ b/create_prj_db.R
@@ -13,12 +13,12 @@ process_type <- "2"
 overwrite <- TRUE
 
 # source database
-src_dbase <- "../../data_modernization/fn_portal_data_in/NearshoreMapper.accdb"
+src_dbase <- "../../data_modernization/fn_portal_data_in/NearshoreMapper_template3.accdb"
 
 #src_dbase <-"C:/Users/COTTRILLAD/1work/Python/djcode/apps/fn_portal/utils/data_upload_src/OffshoreMapper.accdb"
 
 # template database:
-template_db <- "../../data_modernization/fn_portal_data_in/templates/Great_Lakes_Template2_template.accdb"
+template_db <- "../../data_modernization/fn_portal_data_in/templates/Great_Lakes_Template3_template.accdb"
 
 trg_db <- file.path(dirname(src_dbase),'build', paste0(prj_cd, '.accdb'))
 
@@ -27,16 +27,20 @@ file.copy(template_db, trg_db, overwrite=overwrite)
 
 fn011 <- fetch_data('FN011', prj_cd, src_dbase)
 head(fn011)
+fn011$PRJ_DATE0 <- as.Date(fn011$PRJ_DATE0)
+fn011$PRJ_DATE1 <- as.Date(fn011$PRJ_DATE1)
 append_data(trg_db, 'FN011', fn011)
 
 
 fn012 <- fetch_data('FN012', prj_cd, src_dbase)
 head(fn012)
-append_data(trg_db, 'FN011', fn012)
+append_data(trg_db, 'FN012', fn012)
 
 
 fn022 <- fetch_data('FN022', prj_cd, src_dbase)
 head(fn022)
+fn022$SSN_DATE0 <- as.Date(fn022$SSN_DATE0)
+fn022$SSN_DATE1 <- as.Date(fn022$SSN_DATE1)
 append_data(trg_db, 'FN022', fn022)
 
 
@@ -46,9 +50,9 @@ append_data(trg_db, 'FN026', fn026)
 
 
 fn028 <- fetch_data('FN028', prj_cd, src_dbase)
-# don't worry about the wrong dates in the EFFTM0_GE and EFFTM0_LE columns;
-# the times are correct and only the times get read into Access
 head(fn028)
+fn028$EFFTM0_GE <- get_time(fn028$EFFTM0_GE)
+fn028$EFFTM0_LT <- get_time(fn028$EFFTM0_LT)
 #increment mode here:
 fn028$MODE <- paste0(seq(1, nrow(fn028)), 0)
 append_data(trg_db, 'FN028', fn028)
@@ -58,7 +62,6 @@ append_data(trg_db, 'FN028', fn028)
 gear_effort_process_types <- get_gear_process_types()
 gear_effort_process_types <- subset(gear_effort_process_types, GR %in% fn028$GR & PROCESS_TYPE==process_type)
 
-
 append_data(trg_db, 'Gear_Effort_Process_Types', gear_effort_process_types)
 
 
@@ -67,6 +70,10 @@ fn121 <- add_mode(fn121, fn028)
 fn121$SSN <- "00"
 fn121$SPACE <- "00"
 fn121$PROCESS_TYPE <- process_type
+fn121$EFFDT0 <- as.Date(fn121$EFFDT0)
+fn121$EFFDT1 <- as.Date(fn121$EFFDT1)
+fn121$EFFTM0 <- get_time(fn121$EFFTM0)
+fn121$EFFTM1 <- get_time(fn121$EFFTM1)
 
 fn121 <- subset(fn121, select=-c(GR,GRUSE, ORIENT))
 head(fn121)
@@ -106,12 +113,10 @@ update_FN125_lam_flag(trg_db)
 fn126 <- fetch_data('FN126', prj_cd, src_dbase)
 head(fn126)
 append_data(trg_db, 'FN126', fn126)
-
 update_FN125_stom_flag(trg_db)
 
 
 fn127 <- fetch_data('FN127', prj_cd, src_dbase)
 head(fn127)
 append_data(trg_db, 'FN127', fn127)
-
 update_FN125_age_flag(trg_db)

--- a/data_mapper_utils.R
+++ b/data_mapper_utils.R
@@ -39,6 +39,20 @@ fetch_data <- function(table, prj_cd, src_db, toupper=T){
   return(dat)
 }
 
+
+get_time <- function(datetime){
+  # extract time from date/time string
+  time_regex <- ".*([0-2][0-9]:[0-5][0-9]:[0-5][0-9])$"
+  datetime <- gsub(time_regex, "\\1", datetime, perl = TRUE)
+  msg <- "One or more values is not a valid time or datetime. The time component should be in the format HH:MM:SS."
+  
+  ifelse(!grepl(time_regex, datetime),
+         stop(msg),
+         datetime)
+  
+}
+
+
 # function to append data to the template
 append_data <- function(dbase, trg_table, data, append=T, safer=T,
                         toupper=T, verbose=F){


### PR DESCRIPTION
Add get_time() function to separate time character string from dates. Set date columns to date type and time columns to string matching HH:MM:SS.